### PR TITLE
Fix `no_std` and add CI check

### DIFF
--- a/.github/workflows/no_std.yml
+++ b/.github/workflows/no_std.yml
@@ -1,7 +1,7 @@
 on:
   workflow_dispatch:
   push:
-    branches: [ '**' ]
+    branches: [ master ]
   pull_request:
     branches: [ '**' ]
 

--- a/.github/workflows/no_std.yml
+++ b/.github/workflows/no_std.yml
@@ -1,0 +1,24 @@
+on:
+  workflow_dispatch:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ '**' ]
+
+jobs:
+  build-nostd:
+    name: Build on no_std target (thumbv7em-none-eabi)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+          targets: thumbv7em-none-eabi
+      - uses: taiki-e/install-action@cargo-hack
+      # No default features build
+      - name: no_std / no feat
+        run: cargo build --target thumbv7em-none-eabi --release --no-default-features
+      # cargo hack ensures all no_std features all built-checked
+      - name: no_std / cargo hack features
+        run: cargo hack build --target thumbv7em-none-eabi --release --each-feature --exclude-features default,std,getrandom,wasm,benchmarking

--- a/.github/workflows/no_std.yml
+++ b/.github/workflows/no_std.yml
@@ -21,4 +21,4 @@ jobs:
         run: cargo build --target thumbv7em-none-eabi --release --no-default-features
       # cargo hack ensures all no_std features all built-checked
       - name: no_std / cargo hack features
-        run: cargo hack build --target thumbv7em-none-eabi --release --each-feature --exclude-features default,std,getrandom,wasm,benchmarking
+        run: cargo hack build --target thumbv7em-none-eabi --release --each-feature --exclude-features default,std,getrandom,wasm,benchmarking,kyber1024

--- a/.github/workflows/no_std.yml
+++ b/.github/workflows/no_std.yml
@@ -1,7 +1,7 @@
 on:
   workflow_dispatch:
   push:
-    branches: [ master ]
+    branches: [ '**' ]
   pull_request:
     branches: [ '**' ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,22 +11,20 @@ description = "Fork of pqc_kyber with some safety fixes"
 keywords = ["kyber", "kem", "key-exchange", "kex", "post-quantum"]
 readme = "readme.md"
 
+resolver = "2"
+
 [dependencies]
 rand_core = { version = "0.6.4",  default-features = false }
 wasm-bindgen = { version = "0.2.84", optional = true }
-getrandom = {version = "0.2.9", features = ["js"], optional = true }
 zeroize = { version = "1.6.0", features = ["derive"], optional = true }
-# Optional dev-deps, see https://github.com/rust-lang/cargo/issues/1596
+# wasm needs rand - TODO: remove
+rand = { version = "0.8", default-features = false, optional = true }
+getrandom = {version = "0.2.9", default-features = false, optional = true }
 criterion = { version = "0.4.0", features = ["html_reports"], optional = true } 
 
-[dependencies.rand]
-version = "0.8.5"
-default-features = false
-features = ["getrandom"]
-optional = true
-
 [dev-dependencies]
-rand = "0.8.5"
+rand = { version = "0.8", default-features = false, features = ["std", "std_rng", "getrandom"] }
+rand_core = { version = "0.6", default-features = false, features = ["getrandom"] }
 
 [build-dependencies]
 
@@ -38,6 +36,7 @@ name = "api"
 harness = false
 
 [features]
+default = []
 ### Security Levels ###
 # Defaults to "kyber768" if none selected
 # Will throw a compile-time error if more than one level is chosen
@@ -46,7 +45,7 @@ kyber768 = []
 kyber1024 = []
 
 # For compiling to wasm targets 
-wasm = ["wasm-bindgen", "getrandom", "rand"]
+wasm = ["wasm-bindgen", "rand/getrandom", "rand_core/getrandom", "getrandom/js"]
 
 # Enable std library support
 std = []


### PR DESCRIPTION
As is established standard in [curve25519-dalek](https://github.com/dalek-cryptography/curve25519-dalek/blob/main/.github/workflows/workspace.yml#L60) and [fiat-crypto](https://github.com/mit-plv/fiat-crypto/blob/master/.github/workflows/rust.yml#L34)